### PR TITLE
Immediately update oldLocale if no initial value set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project is the Component wrapper implementation of [`<vaadin-date-picker>`](https://github.com/vaadin/vaadin-date-picker) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
+This branch is Vaadin 11 compatible. See other branches for other framework versions:
+* master branch is Vaadin 11 (Flow version 1.1)
+* 1.0 branch is Vaadin 10 (Flow version 1.0)
+
 ## Running the component demo
 Run from the command line:
 - `mvn jetty:run -PrunTests`

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-components-testbench</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-component-demo-helpers</artifactId>
             <version>${flow.version}</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-component-base</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-date-picker-flow</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <properties>
-        <flow.version>1.0-SNAPSHOT</flow.version>
+        <flow.version>1.1-SNAPSHOT</flow.version>
     </properties>
 
     <repositories>

--- a/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -116,7 +116,12 @@ window.Vaadin.Flow.datepickerConnector = {
                 };
             };
 
-            updateFormat();
+            let inputValue = datepicker._inputValue || '';
+            if (inputValue === "") {
+                oldLocale = locale;
+            } else {
+                updateFormat();
+            }
         }
     }
 }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
@@ -25,7 +26,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     public void testPickerWithValueAndLocaleFromServerSideDifferentCtor() {
         open();
 
-        TestBenchElement localePicker = $(TestBenchElement.class)
+        DatePickerElement localePicker = $(DatePickerElement.class)
                 .id("locale-picker-server-with-value");
         WebElement displayText = localePicker.$(TestBenchElement.class)
                 .id("input");
@@ -38,7 +39,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 "23/04/2018",
                 executeScript("return arguments[0].value", displayText));
 
-        localePicker = $(TestBenchElement.class)
+        localePicker = $(DatePickerElement.class)
                 .id("french-locale-date-picker");
         displayText = localePicker.$(TestBenchElement.class).id("input");
 
@@ -52,9 +53,9 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertThat(logs.get(0).getMessage(), CoreMatchers.containsString(
                 "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated"));
 
-        localePicker = $(TestBenchElement.class)
+        localePicker = $(DatePickerElement.class)
                 .id("german-locale-date-picker");
-        executeScript("arguments[0].value = '10.01.1985'", localePicker);
+        localePicker.setProperty("value", "10.01.1985");
 
         logs = getWaringEntries();
 

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -3,7 +3,6 @@ package com.vaadin.flow.component.datepicker;
 import java.util.logging.Level;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -11,6 +10,7 @@ import org.openqa.selenium.logging.LogEntries;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("date-picker-locale")
 public class DatePickerLocaleIT extends AbstractComponentIT {
@@ -21,39 +21,46 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     public void testPickerWithValueAndLocaleFromServerSideDifferentCtor() {
         open();
 
-        WebElement localePicker = findElement(
-                By.id("locale-picker-server-with-value"));
-        WebElement displayText = findInShadowRoot(localePicker, By.id("input"))
-                .get(0);
+        TestBenchElement localePicker = $(TestBenchElement.class).id("locale-picker-server-with-value");
+        WebElement displayText = localePicker.$(TestBenchElement.class).id("input");
 
         Assert.assertEquals("Wrong initial date in field.", "2018/4/23",
                 executeScript("return arguments[0].value", displayText));
 
         findElement(By.id("uk-locale")).click();
-        Assert.assertEquals("Didn't have expected UK locale date.", "23/04/2018",
+        Assert.assertEquals("Didn't have expected UK locale date.",
+                "23/04/2018",
                 executeScript("return arguments[0].value", displayText));
 
-        localePicker = findElement(By.id("french-locale-date-picker"));
-        displayText = findInShadowRoot(localePicker, By.id("input")).get(0);
+        localePicker = $(TestBenchElement.class).id("french-locale-date-picker");
+        displayText = localePicker.$(TestBenchElement.class).id("input");
 
-        Assert.assertEquals("French locale date had wrong format",
-                "30/05/2018",
+        Assert.assertEquals("French locale date had wrong format", "30/05/2018",
                 executeScript("return arguments[0].value", displayText));
 
-        LogEntries logs  =  driver.manage().logs().get("browser");
 
-        Assert.assertEquals("Expected only [Deprecation] warning should be in the logs", 1, logs.filter(Level.WARNING).size());
+        assertBrowserLogs();
 
-        localePicker = findElement(By.id("german-locale-date-picker"));
-        executeScript("arguments[0].value = '10.01.1985'", localePicker);
+        localePicker = $(TestBenchElement.class).id("german-locale-date-picker");
+        executeScript("arguments[0].value = '10.01.1985';", localePicker);
 
-        logs  =  driver.manage().logs().get("browser");
+        assertBrowserLogs();
 
-        Assert.assertEquals("Expected only [Deprecation] warning should be in the logs", 1, logs.filter(Level.WARNING).size());
-
-        displayText = findInShadowRoot(localePicker, By.id("input")).get(0);
-        Assert.assertEquals("Didn't have expected German locale date.", "23.04.2018",
+        displayText = localePicker.$(TestBenchElement.class).id("input");
+        Assert.assertEquals("Didn't have expected German locale date.",
+                "10.01.1985",
                 executeScript("return arguments[0].value", displayText));
 
+    }
+
+    private void assertBrowserLogs() {
+        LogEntries logs = driver.manage().logs().get("browser");
+
+        Assert.assertEquals(
+                "Expected only [Deprecation] warning should be in the logs", 1,
+                logs.filter(Level.WARNING).size());
+        Assert.assertEquals(
+                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
+                logs.filter(Level.WARNING).get(0).getMessage());
     }
 }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -1,16 +1,21 @@
 package com.vaadin.flow.component.datepicker;
 
+import java.util.logging.Level;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.logging.LogEntries;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
 @TestPath("date-picker-locale")
 public class DatePickerLocaleIT extends AbstractComponentIT {
+
+    private static final String DATEPICKER_OVERLAY = "vaadin-date-picker-overlay";
 
     @Test
     public void testPickerWithValueAndLocaleFromServerSideDifferentCtor() {
@@ -34,5 +39,21 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals("French locale date had wrong format",
                 "30/05/2018",
                 executeScript("return arguments[0].value", displayText));
+
+        LogEntries logs  =  driver.manage().logs().get("browser");
+
+        Assert.assertEquals("Expected only [Deprecation] warning should be in the logs", 1, logs.filter(Level.WARNING).size());
+
+        localePicker = findElement(By.id("german-locale-date-picker"));
+        executeScript("arguments[0].value = '10.01.1985'", localePicker);
+
+        logs  =  driver.manage().logs().get("browser");
+
+        Assert.assertEquals("Expected only [Deprecation] warning should be in the logs", 1, logs.filter(Level.WARNING).size());
+
+        displayText = findInShadowRoot(localePicker, By.id("input")).get(0);
+        Assert.assertEquals("Didn't have expected German locale date.", "23.04.2018",
+                executeScript("return arguments[0].value", displayText));
+
     }
 }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -58,11 +58,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
         logs = getWaringEntries();
 
-        Assert.assertEquals(
-                "Expected only [Deprecation] warning should be in the logs", 1,
-                logs.size());
-        Assert.assertThat(logs.get(0).getMessage(), CoreMatchers.containsString(
-                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated"));
+        Assert.assertTrue("No new warnings should have appeared in the logs",
+                logs.isEmpty());
 
         displayText = localePicker.$(TestBenchElement.class).id("input");
         Assert.assertEquals("Didn't have expected German locale date.",

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -39,21 +39,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 executeScript("return arguments[0].value", displayText));
 
 
-        assertBrowserLogs();
 
-        localePicker = $(TestBenchElement.class).id("german-locale-date-picker");
-        executeScript("arguments[0].value = '10.01.1985';", localePicker);
-
-        assertBrowserLogs();
-
-        displayText = localePicker.$(TestBenchElement.class).id("input");
-        Assert.assertEquals("Didn't have expected German locale date.",
-                "10.01.1985",
-                executeScript("return arguments[0].value", displayText));
-
-    }
-
-    private void assertBrowserLogs() {
         LogEntries logs = driver.manage().logs().get("browser");
 
         Assert.assertEquals(
@@ -62,5 +48,24 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals(
                 "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
                 logs.filter(Level.WARNING).get(0).getMessage());
+
+        localePicker = $(TestBenchElement.class).id("german-locale-date-picker");
+        executeScript("arguments[0].value = '10.01.1985'", localePicker);
+
+        logs = driver.manage().logs().get("browser");
+
+        Assert.assertEquals(
+                "Expected only [Deprecation] warning should be in the logs", 1,
+                logs.filter(Level.WARNING).size());
+        Assert.assertEquals(
+                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
+                logs.filter(Level.WARNING).get(0).getMessage());
+
+
+        displayText = localePicker.$(TestBenchElement.class).id("input");
+        Assert.assertEquals("Didn't have expected German locale date.",
+                "10.01.1985",
+                executeScript("return arguments[0].value", displayText));
+
     }
 }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -24,8 +25,10 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     public void testPickerWithValueAndLocaleFromServerSideDifferentCtor() {
         open();
 
-        TestBenchElement localePicker = $(TestBenchElement.class).id("locale-picker-server-with-value");
-        WebElement displayText = localePicker.$(TestBenchElement.class).id("input");
+        TestBenchElement localePicker = $(TestBenchElement.class)
+                .id("locale-picker-server-with-value");
+        WebElement displayText = localePicker.$(TestBenchElement.class)
+                .id("input");
 
         Assert.assertEquals("Wrong initial date in field.", "2018/4/23",
                 executeScript("return arguments[0].value", displayText));
@@ -35,7 +38,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 "23/04/2018",
                 executeScript("return arguments[0].value", displayText));
 
-        localePicker = $(TestBenchElement.class).id("french-locale-date-picker");
+        localePicker = $(TestBenchElement.class)
+                .id("french-locale-date-picker");
         displayText = localePicker.$(TestBenchElement.class).id("input");
 
         Assert.assertEquals("French locale date had wrong format", "30/05/2018",
@@ -45,11 +49,11 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals(
                 "Expected only [Deprecation] warning should be in the logs", 1,
                 logs.size());
-        Assert.assertEquals(
-                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
-                logs.get(0).getMessage());
+        Assert.assertThat(logs.get(0).getMessage(), CoreMatchers.containsString(
+                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated"));
 
-        localePicker = $(TestBenchElement.class).id("german-locale-date-picker");
+        localePicker = $(TestBenchElement.class)
+                .id("german-locale-date-picker");
         executeScript("arguments[0].value = '10.01.1985'", localePicker);
 
         logs = getWaringEntries();
@@ -57,10 +61,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals(
                 "Expected only [Deprecation] warning should be in the logs", 1,
                 logs.size());
-        Assert.assertEquals(
-                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
-                logs.get(0).getMessage());
-
+        Assert.assertThat(logs.get(0).getMessage(), CoreMatchers.containsString(
+                "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated"));
 
         displayText = localePicker.$(TestBenchElement.class).id("input");
         Assert.assertEquals("Didn't have expected German locale date.",
@@ -71,7 +73,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
     private List<LogEntry> getWaringEntries() {
         LogEntries logs = driver.manage().logs().get("browser");
-        return logs.getAll().stream().filter(log -> log.getLevel().equals(Level.WARNING)).collect(
-                Collectors.toList());
+        return logs.getAll().stream()
+                .filter(log -> log.getLevel().equals(Level.WARNING))
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -57,6 +57,9 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         localePicker = $(DatePickerElement.class)
                 .id("german-locale-date-picker");
         localePicker.setDate(LocalDate.of(1985,1,10));
+        localePicker.setProperty("opened", true);
+        waitForElementPresent(By.tagName(DATEPICKER_OVERLAY));
+        localePicker.setProperty("opened", false);
 
         logs = getWaringEntries();
 

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -47,7 +47,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals("French locale date had wrong format", "30/05/2018",
                 executeScript("return arguments[0].value", displayText));
 
-        List<LogEntry> logs = getWaringEntries();
+        List<LogEntry> logs = getWarningEntries();
         Assert.assertEquals(
                 "Expected only [Deprecation] warning should be in the logs", 1,
                 logs.size());
@@ -59,7 +59,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         localePicker.setDate(LocalDate.of(1985,1,10));
         findElement(By.tagName("body")).click();
 
-        logs = getWaringEntries();
+        logs = getWarningEntries();
 
         Assert.assertTrue("No new warnings should have appeared in the logs",
                 logs.isEmpty());
@@ -71,7 +71,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
     }
 
-    private List<LogEntry> getWaringEntries() {
+    private List<LogEntry> getWarningEntries() {
         LogEntries logs = driver.manage().logs().get("browser");
         return logs.getAll().stream()
                 .filter(log -> log.getLevel().equals(Level.WARNING))

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -57,9 +57,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         localePicker = $(DatePickerElement.class)
                 .id("german-locale-date-picker");
         localePicker.setDate(LocalDate.of(1985,1,10));
-        localePicker.setProperty("opened", true);
-        waitForElementPresent(By.tagName(DATEPICKER_OVERLAY));
-        localePicker.setProperty("opened", false);
+        findElement(By.tagName("body")).click();
 
         logs = getWaringEntries();
 

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -41,7 +41,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
 
         LogEntries logs = driver.manage().logs().get("browser");
-
+logs.filter(Level.WARNING).forEach(log -> System.out.println("=== " + log));
         Assert.assertEquals(
                 "Expected only [Deprecation] warning should be in the logs", 1,
                 logs.filter(Level.WARNING).size());

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -66,7 +66,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
         displayText = localePicker.$(TestBenchElement.class).id("input");
         Assert.assertEquals("Didn't have expected German locale date.",
-                "10.01.1985",
+                "10.1.1985",
                 executeScript("return arguments[0].value", displayText));
 
     }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.datepicker;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
         localePicker = $(DatePickerElement.class)
                 .id("german-locale-date-picker");
-        localePicker.setProperty("value", "10.01.1985");
+        localePicker.setDate(LocalDate.of(1985,1,10));
 
         logs = getWaringEntries();
 

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -1,12 +1,15 @@
 package com.vaadin.flow.component.datepicker;
 
+import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
@@ -38,28 +41,25 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals("French locale date had wrong format", "30/05/2018",
                 executeScript("return arguments[0].value", displayText));
 
-
-
-        LogEntries logs = driver.manage().logs().get("browser");
-logs.filter(Level.WARNING).forEach(log -> System.out.println("=== " + log));
+        List<LogEntry> logs = getWaringEntries();
         Assert.assertEquals(
                 "Expected only [Deprecation] warning should be in the logs", 1,
-                logs.filter(Level.WARNING).size());
+                logs.size());
         Assert.assertEquals(
                 "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
-                logs.filter(Level.WARNING).get(0).getMessage());
+                logs.get(0).getMessage());
 
         localePicker = $(TestBenchElement.class).id("german-locale-date-picker");
         executeScript("arguments[0].value = '10.01.1985'", localePicker);
 
-        logs = driver.manage().logs().get("browser");
+        logs = getWaringEntries();
 
         Assert.assertEquals(
                 "Expected only [Deprecation] warning should be in the logs", 1,
-                logs.filter(Level.WARNING).size());
+                logs.size());
         Assert.assertEquals(
                 "deprecation - Styling master document from stylesheets defined in HTML Imports is deprecated. Please refer to https://goo.gl/EGXzpw for possible migration paths.",
-                logs.filter(Level.WARNING).get(0).getMessage());
+                logs.get(0).getMessage());
 
 
         displayText = localePicker.$(TestBenchElement.class).id("input");
@@ -67,5 +67,11 @@ logs.filter(Level.WARNING).forEach(log -> System.out.println("=== " + log));
                 "10.01.1985",
                 executeScript("return arguments[0].value", displayText));
 
+    }
+
+    private List<LogEntry> getWaringEntries() {
+        LogEntries logs = driver.manage().logs().get("browser");
+        return logs.getAll().stream().filter(log -> log.getLevel().equals(Level.WARNING)).collect(
+                Collectors.toList());
     }
 }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -27,13 +27,16 @@ public class DatePickerLocalePage extends Div {
 
         locale.addClickListener(e -> datePicker.setLocale(Locale.UK));
 
-
         DatePicker frenchLocale = new DatePicker();
         frenchLocale.setId("french-locale-date-picker");
 
         frenchLocale.setLocale(Locale.FRANCE);
         frenchLocale.setValue(may30th);
 
-        add(datePicker, locale, frenchLocale);
+        DatePicker german = new DatePicker();
+        german.setLocale(Locale.GERMANY);
+        german.setId("german-locale-date-picker");
+
+        add(datePicker, locale, frenchLocale, german);
     }
 }


### PR DESCRIPTION
If the oldLocale is not updated for the empty input then the
first time a date is selected we receive a
`Selected locale is using unsupported date format, which might affect the parsing date.`
warning in the console for non default en-US locales.

Fixes #103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/104)
<!-- Reviewable:end -->
