### PR TITLE
Fixes locale issue and web component not in dom -issue and console error flooding (#125)

### DIFF
--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -40,12 +40,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 "23/04/2018",
                 executeScript("return arguments[0].value", displayText));
 
-        localePicker = $(DatePickerElement.class)
-                .id("french-locale-date-picker");
-        displayText = localePicker.$(TestBenchElement.class).id("input");
-
-        Assert.assertEquals("French locale date had wrong format", "30/05/2018",
-                executeScript("return arguments[0].value", displayText));
+        assertText($(DatePickerElement.class).id("french-locale-date-picker"),
+                "03/05/2018");
 
         List<LogEntry> logs = getWarningEntries();
         Assert.assertEquals(
@@ -64,11 +60,22 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertTrue("No new warnings should have appeared in the logs",
                 logs.isEmpty());
 
-        displayText = localePicker.$(TestBenchElement.class).id("input");
-        Assert.assertEquals("Didn't have expected German locale date.",
-                "10.1.1985",
-                executeScript("return arguments[0].value", displayText));
+        assertText(localePicker, "10.1.1985");
 
+        assertText($(DatePickerElement.class).id("korean-locale-date-picker"),
+                "2018. 5. 3.");
+
+        assertText($(DatePickerElement.class).id("polish-locale-date-picker"),
+                "3.05.2018");
+
+    }
+
+    private void assertText(DatePickerElement datePickerElement,
+            String expected) {
+        WebElement displayText = datePickerElement.$(TestBenchElement.class).id("input");
+        Assert.assertEquals("Didn't have expected locale date.",
+                expected,
+                executeScript("return arguments[0].value", displayText));
     }
 
     private List<LogEntry> getWarningEntries() {
@@ -79,14 +86,14 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
     }
 
     @Test
-    public void hungarianLocaleTest() {
+    public void polishLocaleTest() {
         open();
 
         checkLogsForErrors();
-        WebElement hungarianPicker = findElement(
-                By.id("hungarian-locale-date-picker"));
+        WebElement polishPicker = findElement(
+                By.id("polish-locale-date-picker"));
         // trigger the validation on the from clientside
-        hungarianPicker.click();
+        polishPicker.click();
         executeScript("document.body.click()");
 
         checkLogsForErrors();

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -11,15 +11,10 @@ import com.vaadin.flow.router.Route;
 @Route("date-picker-locale")
 public class DatePickerLocalePage extends Div {
 
-    private final LocalDate may30th = LocalDate.of(2018, Month.MAY, 30);
+    private final LocalDate may3rd = LocalDate.of(2018, Month.MAY, 3);
     private final LocalDate april23rd = LocalDate.of(2018, Month.APRIL, 23);
 
     public DatePickerLocalePage() {
-        createPickerWithValueAndLocaleViaDifferentCtor();
-        addHungarianLocale();
-    }
-
-    private void createPickerWithValueAndLocaleViaDifferentCtor() {
         DatePicker datePicker = new DatePicker(april23rd, Locale.CHINA);
         datePicker.setId("locale-picker-server-with-value");
 
@@ -32,18 +27,22 @@ public class DatePickerLocalePage extends Div {
         frenchLocale.setId("french-locale-date-picker");
 
         frenchLocale.setLocale(Locale.FRANCE);
-        frenchLocale.setValue(may30th);
+        frenchLocale.setValue(may3rd);
 
         DatePicker german = new DatePicker();
         german.setLocale(Locale.GERMANY);
         german.setId("german-locale-date-picker");
 
         add(datePicker, locale, frenchLocale, german);
+
+        DatePicker polandDatePicker = new DatePicker(may3rd, new Locale("pl", "PL"));
+        polandDatePicker.setId("polish-locale-date-picker");
+        add(polandDatePicker);
+
+        DatePicker korean = new DatePicker(may3rd, new Locale("ko", "KR"));
+        korean.setId("korean-locale-date-picker");
+        add(korean);
+
     }
 
-    private void addHungarianLocale() {
-        DatePicker datePicker = new DatePicker(may30th, new Locale("hu", "HU"));
-        datePicker.setId("hungarian-locale-date-picker");
-        add(datePicker);
-    }
 }


### PR DESCRIPTION
* Fixes locale issue and web component not in dom -issue and console error flooding.

- try-catch -test for testing components existence in dom
- reverse engineer regex out of date.toLocaleDateString
- use given regex to parse input values
- removed error flooding

Fixes #90
Fixes #116
Fixes #117

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/127)
<!-- Reviewable:end -->
