### PR TITLE
I18Ned DatePicker fails on the frontend because the language tag is incorrect

### DIFF
--- a/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -254,7 +254,7 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     public void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale must not be null.");
         this.locale = locale;
-        String languageTag = locale.getLanguage() + "-" + locale.getCountry();
+        String languageTag = locale.toLanguageTag();
         runBeforeClientResponse(ui -> getElement()
                 .callFunction("$connector.setLocale", languageTag));
     }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -30,7 +30,7 @@ public class DatePickerLocalePage extends Div {
         frenchLocale.setValue(may3rd);
 
         DatePicker german = new DatePicker();
-        german.setLocale(Locale.GERMANY);
+        german.setLocale(Locale.GERMAN);
         german.setId("german-locale-date-picker");
 
         add(datePicker, locale, frenchLocale, german);

--- a/src/test/java/com/vaadin/flow/component/datepicker/demo/DatePickerView.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/demo/DatePickerView.java
@@ -109,6 +109,7 @@ public class DatePickerView extends DemoView {
         DatePicker datePicker = new DatePicker();
         datePicker.setLabel("Finnish date picker");
         datePicker.setPlaceholder("Syntymäpäivä");
+        datePicker.setLocale(new Locale("fi"));
 
         datePicker.setI18n(
                 new DatePickerI18n().setWeek("viikko").setCalendar("kalenteri")


### PR DESCRIPTION
Hi!

When I try to internationalize the DatePicker component the frontend component gives the following warning:

![image](https://user-images.githubusercontent.com/6528869/49742032-fece6300-fc97-11e8-9419-99fe98df20c5.png)

I think it's because the language tag is incorrectly created on the backend. If the Locale doesn't contain any country info the languageTag will be something like `hu-` (in case of Hungary), but it should be `hu`.

Because of this incorrect language tag, the frontend-component fails to parse the correct language, and all the dates will be formatted US-style.

At the 66th line of the `datePickerConntector.js` you can see the following code:

```js
datepicker.$connector.setLocale = function (locale) {
            try {
                // Check whether the locale is supported or not
                new Date().toLocaleDateString(locale);
            } catch (e) {
                locale = "en-US";
                console.warn("The locale is not supported, use default locale setting(en-US).");
            }
// ...
``` 

The `new Date().toLocaleDateString('hu-')` function really fails, but the `new Date().toLocaleDateString('hu')` does not  and everything works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/150)
<!-- Reviewable:end -->
