### PR TITLE
I18Ned DatePicker fails on the frontend because the language tag is incorrect (#150)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -254,7 +254,7 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     public void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale must not be null.");
         this.locale = locale;
-        String languageTag = locale.getLanguage() + "-" + locale.getCountry();
+        String languageTag = locale.toLanguageTag();
         runBeforeClientResponse(ui -> getElement()
                 .callFunction("$connector.setLocale", languageTag));
     }

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocalePage.java
@@ -30,7 +30,7 @@ public class DatePickerLocalePage extends Div {
         frenchLocale.setValue(may3rd);
 
         DatePicker german = new DatePicker();
-        german.setLocale(Locale.GERMANY);
+        german.setLocale(Locale.GERMAN);
         german.setId("german-locale-date-picker");
 
         add(datePicker, locale, frenchLocale, german);

--- a/src/test/java/com/vaadin/flow/component/datepicker/demo/DatePickerView.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/demo/DatePickerView.java
@@ -109,6 +109,7 @@ public class DatePickerView extends DemoView {
         DatePicker datePicker = new DatePicker();
         datePicker.setLabel("Finnish date picker");
         datePicker.setPlaceholder("Syntymäpäivä");
+        datePicker.setLocale(new Locale("fi"));
 
         datePicker.setI18n(
                 new DatePickerI18n().setWeek("viikko").setCalendar("kalenteri")


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/151)
<!-- Reviewable:end -->
