### PR TITLE
1.2.4 cherry picks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
                 <configuration>
                     <webApp>
                         <resourceBases>

--- a/src/test/java/com/vaadin/flow/component/datepicker/DatePickerSerializableTest.java
+++ b/src/test/java/com/vaadin/flow/component/datepicker/DatePickerSerializableTest.java
@@ -3,6 +3,8 @@ package com.vaadin.flow.component.datepicker;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
+import java.util.stream.Stream;
+
 public class DatePickerSerializableTest extends ClassesSerializableTest {
 
     private static final UI FAKE_UI = new UI();
@@ -17,5 +19,12 @@ public class DatePickerSerializableTest extends ClassesSerializableTest {
     protected void setupThreadLocals() {
         super.setupThreadLocals();
         UI.setCurrent(FAKE_UI);
+    }
+
+    @Override
+    protected Stream<String> getExcludedPatterns() {
+        return Stream.concat(super.getExcludedPatterns(), Stream.of(
+                "com\\.vaadin\\.flow\\.component\\.contextmenu\\.osgi\\..*"
+        ));
     }
 }


### PR DESCRIPTION
Cherry-picks:
- Adding osgi classes to excluded patterns in serializable test (#143) 
- removed obsolete jetty version (#149)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/157)
<!-- Reviewable:end -->
