### PR TITLE
Fix build failure after update to Chrome 73 (#167)

### DIFF
--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerValidationPageIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.datepicker;
 import java.util.logging.Level;
 import java.util.stream.IntStream;
 
+import com.google.common.base.Strings;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,7 +26,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-import com.google.common.base.Strings;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
@@ -44,6 +44,7 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
 
     @Before
     public void init() {
+
         open();
         waitForElementPresent(By.id("field"));
         field = findElement(By.id("field"));
@@ -106,13 +107,20 @@ public class DatePickerValidationPageIT extends AbstractComponentIT {
     public void invalidLocale() {
         String logList = getLogEntries(Level.WARNING).toString();
         Assert.assertFalse(logList.contains(
-                "The locale is not supported, use default locale setting(en-US)."));
+                "The locale is not supported, using default locale setting(en-US)."));
 
         WebElement changeLocale = findElement(By.id("change-locale"));
         scrollIntoViewAndClick(changeLocale);
 
         waitUntil(driver -> getLogEntries(Level.WARNING).toString().contains(
-                "The locale is not supported, use default locale setting(en-US)."));
+                "The locale is not supported, using default locale setting(en-US)."));
+        WebElement picker = findElement(By.id("field"));
+        WebElement displayText = findInShadowRoot(picker, By.id("input")).get(0);
+
+        executeScript("arguments[0].value = '2018-12-26'", picker);
+        Assert.assertEquals("DatePicker should use default locale(en-US) format, MM/DD/YYYY", true,
+                executeScript("return arguments[0].value === '12/26/2018'",
+                        displayText));
     }
 
     @Test

--- a/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -64,12 +64,13 @@ window.Vaadin.Flow.datepickerConnector = {
         }
 
         datepicker.$connector.setLocale = function (locale) {
+
             try {
                 // Check whether the locale is supported or not
                 new Date().toLocaleDateString(locale);
             } catch (e) {
                 locale = "en-US";
-                console.warn("The locale is not supported, use default locale setting(en-US).");
+                console.warn("The locale is not supported, using default locale setting(en-US).");
             }
 
             let currentDate = false;


### PR DESCRIPTION
* Fix build failure after update to Chrome 73

* Use default locale, when ill-formed locale got detected

* Handle the changes on server side

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/168)
<!-- Reviewable:end -->
