### PR TITLE
Bump lumo-webjar to fix non-pinned deps build

### DIFF
--- a/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-lumo-styles</artifactId>
-            <version>1.3.3</version>
+            <version>1.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.polymerelements</groupId>


### PR DESCRIPTION
The snapshot build is failing because it selects the version of
vaadin-lumo-styles from a range. This fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/177)
<!-- Reviewable:end -->
