### PR TITLE
Run JS for locale and i18n on attach

### DIFF
--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DetachAttachPage.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DetachAttachPage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Locale;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("detach-attach")
+public class DetachAttachPage extends Div {
+
+    public DetachAttachPage() {
+        DatePicker datePicker = new DatePicker(
+                LocalDate.of(1993, Month.JUNE, 13));
+
+        datePicker.setLocale(Locale.FRANCE);
+        datePicker.setI18n(TestI18N.FINNISH);
+
+        NativeButton detach = new NativeButton("detach",
+                e -> remove(datePicker));
+        detach.setId("detach");
+        NativeButton attach = new NativeButton("attach", e -> add(datePicker));
+        attach.setId("attach");
+
+        add(datePicker, detach, attach);
+    }
+
+}

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/InjectedDatePickerI18nPage.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/InjectedDatePickerI18nPage.java
@@ -15,10 +15,7 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import java.util.Arrays;
-
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.polymertemplate.Id;
@@ -36,16 +33,6 @@ public class InjectedDatePickerI18nPage extends PolymerTemplate<TemplateModel> {
     private DatePicker datePicker;
 
     public InjectedDatePickerI18nPage() {
-        DatePickerI18n i18n = new DatePickerI18n().setWeek("viikko")
-                .setCalendar("kalenteri").setClear("tyhjennä")
-                .setToday("tänään").setCancel("peruuta").setFirstDayOfWeek(1)
-                .setMonthNames(Arrays.asList("tammiku", "helmikuu", "maaliskuu",
-                        "huhtikuu", "toukokuu", "kesäkuu", "heinäkuu", "elokuu",
-                        "syyskuu", "lokakuu", "marraskuu", "joulukuu"))
-                .setWeekdays(Arrays.asList("sunnuntai", "maanantai", "tiistai",
-                        "keskiviikko", "torstai", "perjantai", "lauantai"))
-                .setWeekdaysShort(Arrays.asList("su", "ma", "ti", "ke", "to",
-                        "pe", "la"));
-        datePicker.setI18n(i18n);
+        datePicker.setI18n(TestI18N.FINNISH);
     }
 }

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/TestI18N.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/TestI18N.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import java.util.Arrays;
+
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
+
+public class TestI18N {
+
+    public static final DatePickerI18n FINNISH = new DatePickerI18n()
+            .setWeek("viikko").setCalendar("kalenteri").setClear("tyhjennä")
+            .setToday("tänään").setCancel("peruuta").setFirstDayOfWeek(1)
+            .setMonthNames(Arrays.asList("tammikuu", "helmikuu", "maaliskuu",
+                    "huhtikuu", "toukokuu", "kesäkuu", "heinäkuu", "elokuu",
+                    "syyskuu", "lokakuu", "marraskuu", "joulukuu"))
+            .setWeekdays(Arrays.asList("sunnuntai", "maanantai", "tiistai",
+                    "keskiviikko", "torstai", "perjantai", "lauantai"))
+            .setWeekdaysShort(
+                    Arrays.asList("su", "ma", "ti", "ke", "to", "pe", "la"));
+
+    private TestI18N() {
+    }
+}

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DetachAttachIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DetachAttachIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.datepicker;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("detach-attach")
+public class DetachAttachIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void setLocale_detach_reattach_localeCorrect() {
+        Assert.assertEquals(
+                "DatePicker displays unexpected value with French locale.",
+                "13/06/1993", getInputValue());
+        detach();
+        attach();
+        Assert.assertEquals(
+                "DatePicker displays unexpected value with French locale after detach and reattach.",
+                "13/06/1993", getInputValue());
+    }
+
+    @Test
+    public void setI18N_detach_reattach_i18nCorrect() {
+        Assert.assertEquals("peruuta", getCancelText());
+        detach();
+        attach();
+        Assert.assertEquals("peruuta", getCancelText());
+    }
+
+    private void detach() {
+        findElement(By.id("detach")).click();
+    }
+
+    private void attach() {
+        findElement(By.id("attach")).click();
+    }
+
+    private String getInputValue() {
+        return $(DatePickerElement.class).first().$("vaadin-text-field").first()
+                .getPropertyString("value");
+    }
+
+    private String getCancelText() {
+        return (String) executeScript("return arguments[0].i18n.cancel",
+                $(DatePickerElement.class).first());
+    }
+}


### PR DESCRIPTION
Flow creates a new client-side instance on re-attach, so JavaScript
needs to be executed again.

Fix #96

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/186)
<!-- Reviewable:end -->
