### PR TITLE
Fix server side validation

### DIFF
--- a/vaadin-date-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-date-picker-flow-integration-tests/pom-bower-mode.xml
@@ -59,6 +59,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
         </dependency>
+        <!-- Used by BinderValidationView -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.1.0.Final</version>
+        </dependency>
 
         <!--Test scoped -->
         <dependency>

--- a/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -63,6 +63,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
         </dependency>
+        <!-- Used by Binder-->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.1.0.Final</version>
+        </dependency>
 
         <!--Test scoped -->
         <dependency>

--- a/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -63,7 +63,7 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
         </dependency>
-        <!-- Used by Binder-->
+        <!-- Used by BinderValidationView -->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
@@ -1,0 +1,37 @@
+package com.vaadin.flow.component.datepicker;
+
+import java.time.LocalDate;
+
+import javax.validation.constraints.NotNull;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+
+@Route("binder-validation")
+public class BinderValidationView extends Div {
+
+    public BinderValidationView() {
+        Binder<AData> binder = new BeanValidationBinder<>(AData.class);
+
+        DatePicker dateField = new DatePicker("Date");
+        binder.bind(dateField, "date");
+        add(dateField);
+    }
+
+    public static class AData {
+
+        @NotNull
+        private LocalDate date;
+
+
+        public LocalDate getDate() {
+            return date;
+        }
+
+        public void setDate(LocalDate date) {
+            this.date = date;
+        }
+    }
+}

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.datepicker;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 
 import javax.validation.constraints.NotNull;
@@ -20,11 +21,12 @@ public class BinderValidationView extends Div {
         dateField.setMin(LocalDate.of(2019, 1, 1));
 
         // Set invalid indicator label
-        dateField.getElement().addPropertyChangeListener("invalid", event -> {
-            String label = dateField.getElement().getProperty("invalid", false)
+        Element dateFieldElement = dateField.getElement();
+        dateFieldElement.addPropertyChangeListener("invalid", event -> {
+            String label = dateFieldElement.getProperty("invalid", false)
                     ? "invalid"
                     : "valid";
-            dateField.getElement().setProperty("label", label == null ? "" : label);
+            dateFieldElement.setProperty("label", label == null ? "" : label);
         });
 
         binder.forField(dateField).withValidator(value -> value != null &&

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
@@ -21,10 +21,11 @@ public class BinderValidationView extends Div {
         dateField.setMin(LocalDate.of(2019, 1, 1));
 
         // Set invalid indicator label
+        String invalidString = "invalid";
         Element dateFieldElement = dateField.getElement();
-        dateFieldElement.addPropertyChangeListener("invalid", event -> {
-            String label = dateFieldElement.getProperty("invalid", false)
-                    ? "invalid"
+        dateFieldElement.addPropertyChangeListener(invalidString, event -> {
+            String label = dateFieldElement.getProperty(invalidString, false)
+                    ? invalidString
                     : "valid";
             dateFieldElement.setProperty("label", label == null ? "" : label);
         });

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/BinderValidationView.java
@@ -1,22 +1,36 @@
 package com.vaadin.flow.component.datepicker;
 
-import java.time.LocalDate;
-
-import javax.validation.constraints.NotNull;
-
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Route("binder-validation")
 public class BinderValidationView extends Div {
 
-    public BinderValidationView() {
-        Binder<AData> binder = new BeanValidationBinder<>(AData.class);
+    public static final String BINDER_ERROR_MSG = "binder";
 
+    public BinderValidationView() {
+        Binder<AData> binder = new Binder<>(AData.class);
         DatePicker dateField = new DatePicker("Date");
-        binder.bind(dateField, "date");
+
+        // Set date field validation constraint
+        dateField.setMin(LocalDate.of(2019, 1, 1));
+
+        // Set invalid indicator label
+        dateField.getElement().addPropertyChangeListener("invalid", event -> {
+            String label = dateField.getElement().getProperty("invalid", false)
+                    ? "invalid"
+                    : "valid";
+            dateField.getElement().setProperty("label", label == null ? "" : label);
+        });
+
+        binder.forField(dateField).withValidator(value -> value != null &&
+                value.compareTo(LocalDate.of(2019, 2, 1)) > -1, BINDER_ERROR_MSG)
+                .bind(AData::getDate, AData::setDate);
+
         add(dateField);
     }
 
@@ -24,7 +38,6 @@ public class BinderValidationView extends Div {
 
         @NotNull
         private LocalDate date;
-
 
         public LocalDate getDate() {
             return date;

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerWithCustomServerSideValidatorPage.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerWithCustomServerSideValidatorPage.java
@@ -16,14 +16,10 @@
 package com.vaadin.flow.component.datepicker;
 
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Label;
-import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.binder.Binder;
-import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
 import java.time.LocalDate;
-import java.util.Locale;
 
 /**
  * View for testing custom validation with {@link DatePicker}.

--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerWithCustomServerSideValidatorPage.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerWithCustomServerSideValidatorPage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.Route;
+
+import java.time.LocalDate;
+import java.util.Locale;
+
+/**
+ * View for testing custom validation with {@link DatePicker}.
+ */
+@Route("required-field-custom-validator")
+public class DatePickerWithCustomServerSideValidatorPage extends Div {
+
+    public static class LocalDateWrapper {
+        private LocalDate value = LocalDate.of(2019, 1, 2);
+
+        public LocalDate getValue() {
+            return value;
+        }
+
+        public void setValue(LocalDate value) {
+            this.value = value;
+        }
+    }
+
+    public DatePickerWithCustomServerSideValidatorPage() {
+        LocalDateWrapper model = new LocalDateWrapper();
+        Binder<LocalDateWrapper> binder = new Binder<>();
+
+        DatePicker datePicker = new DatePicker();
+
+        binder.forField(datePicker)
+                .withValidator(s -> s.compareTo(LocalDate.of(2019, 1, 1)) == 0, "Date is not 01/01/2019")
+                .asRequired()
+                .bind(LocalDateWrapper::getValue, LocalDateWrapper::setValue);
+        binder.setBean(model);
+
+        binder.validate();
+
+        add(datePicker);
+    }
+}

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerBinderIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerBinderIT.java
@@ -50,10 +50,19 @@ public class DatePickerBinderIT extends AbstractComponentIT {
         field.dispatchEvent("blur");
     }
 
+    private void setInternalValidBinderInvalidValue(DatePickerElement field, int day) {
+        field.setDate(LocalDate.of(2019, 1, day));
+        field.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+        field.dispatchEvent("blur");
+    }
+
     @Test
     public void dateField_internalValidationPass_binderValidationFail_fieldInvalid() {
         DatePickerElement field = $(DatePickerElement.class).first();
         setInternalValidBinderInvalidValue(field);
+        // Double checking to avoid false invalid with `_validateInput`
+        setInternalValidBinderInvalidValue(field, 3);
         assertInvalid(field);
     }
 

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerBinderIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerBinderIT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+
+/**
+ * Integration tests for the {@link BinderValidationView}.
+ */
+@TestPath("binder-validation")
+public class DatePickerBinderIT extends AbstractComponentIT {
+
+    @Test
+    public void selectDateOnSimpleDatePicker() {
+        open();
+        final DatePickerElement element = $(DatePickerElement.class).waitForFirst();
+        element.getProperty("invalid");
+    }
+}

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerBinderIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerBinderIT.java
@@ -15,11 +15,15 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import org.junit.Test;
-
 import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.util.Collections;
 
 
 /**
@@ -28,10 +32,66 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("binder-validation")
 public class DatePickerBinderIT extends AbstractComponentIT {
 
+    @Before
+    public void init() {
+        open();
+    }
+
     @Test
     public void selectDateOnSimpleDatePicker() {
-        open();
         final DatePickerElement element = $(DatePickerElement.class).waitForFirst();
-        element.getProperty("invalid");
+        Assert.assertFalse(element.getPropertyBoolean("invalid"));
+    }
+
+    private void setInternalValidBinderInvalidValue(DatePickerElement field) {
+        field.setDate(LocalDate.of(2019, 1, 2));
+        field.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+        field.dispatchEvent("blur");
+    }
+
+    @Test
+    public void dateField_internalValidationPass_binderValidationFail_fieldInvalid() {
+        DatePickerElement field = $(DatePickerElement.class).first();
+        setInternalValidBinderInvalidValue(field);
+        assertInvalid(field);
+    }
+
+    @Test
+    public void dateField_internalValidationPass_binderValidationFail_validateClient_fieldInvalid() {
+        DatePickerElement field = $(DatePickerElement.class).first();
+
+        setInternalValidBinderInvalidValue(field);
+
+        field.getCommandExecutor().executeScript(
+                "arguments[0].validate(); arguments[0].immediateInvalid = arguments[0].invalid;",
+                field);
+
+        assertInvalid(field);
+        // State before server roundtrip (avoid flash of valid
+        // state)
+        Assert.assertTrue("Unexpected immediateInvalid state",
+                field.getPropertyBoolean("immediateInvalid"));
+    }
+
+    @Test
+    public void dateField_internalValidationPass_binderValidationFail_setClientValid_serverFieldInvalid() {
+        DatePickerElement field = $(DatePickerElement.class).first();
+
+        setInternalValidBinderInvalidValue(field);
+
+        field.getCommandExecutor()
+                .executeScript("arguments[0].invalid = false", field);
+
+        Assert.assertEquals(field.getPropertyString("label"), "invalid");
+    }
+
+    private void assertInvalid(DatePickerElement field) {
+        Assert.assertTrue("Unexpected invalid state",
+                field.getPropertyBoolean("invalid"));
+        Assert.assertEquals(
+                "Expected to have error message configured in the Binder Validator",
+                BinderValidationView.BINDER_ERROR_MSG,
+                field.getPropertyString("errorMessage"));
     }
 }

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerWithCustomValidationIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerWithCustomValidationIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+@TestPath("required-field-custom-validator")
+public class DatePickerWithCustomValidationIT extends AbstractComponentIT {
+
+    @Test
+    public void requiredAndCustomValidationOnServerSide_initialStateIsInvalid_changingToValidValueResetsInvalidFlag() throws Exception {
+        open();
+
+        TestBenchElement dateField = $("vaadin-date-picker").first();
+        TestBenchElement input = dateField.$("vaadin-text-field").first();
+
+        Assert.assertEquals(Boolean.TRUE.toString(), dateField.getAttribute("invalid"));
+        Assert.assertEquals("2019-01-02", dateField.getAttribute("value"));
+
+        while (!input.getAttribute("value").isEmpty()) {
+            input.sendKeys(Keys.BACK_SPACE);
+        }
+        input.sendKeys(Keys.ENTER);
+        Assert.assertEquals("", dateField.getAttribute("value"));
+
+        input.sendKeys("01/01/2019");
+        input.sendKeys(Keys.ENTER);
+
+        Assert.assertEquals("2019-01-01", dateField.getAttribute("value"));
+        Assert.assertEquals(Boolean.FALSE.toString(), dateField.getAttribute("invalid"));
+    }
+}

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DetachAttachIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DetachAttachIT.java
@@ -24,6 +24,8 @@ import org.openqa.selenium.By;
 import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
 
 @TestPath("detach-attach")
 public class DetachAttachIT extends AbstractComponentIT {
@@ -43,6 +45,25 @@ public class DetachAttachIT extends AbstractComponentIT {
         Assert.assertEquals(
                 "DatePicker displays unexpected value with French locale after detach and reattach.",
                 "13/06/1993", getInputValue());
+    }
+
+    @Test
+    public void clientSideValidationIsOverriddenOnAttach() {
+        open();
+
+        assertDatePickerIsValidOnTab();
+
+        // Detaching and attaching date picker
+        detach();
+        attach();
+
+        assertDatePickerIsValidOnTab();
+    }
+
+    private void assertDatePickerIsValidOnTab() {
+        WebElement datePickerElement = $(DatePickerElement.class).first();
+        datePickerElement.sendKeys(Keys.TAB);
+        Assert.assertFalse("Date picker should be valid after Tab", Boolean.parseBoolean(datePickerElement.getAttribute("invalid")));
     }
 
     @Test

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -502,9 +502,9 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     }
 
     @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
+    public void setRequiredIndicatorVisible(boolean required) {
         super.setRequiredIndicatorVisible(required);
-        this.required = requiredIndicatorVisible;
+        this.required = required;
     }
 
     /**

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -91,11 +91,7 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
 
         addValueChangeListener(e -> validate());
 
-        addAttachListener(e ->
-                getElement().executeJs("$0.validate = function (value) {" +
-                                "value = value !== undefined ? value : this._inputValue;" +
-                                "return this.checkValidity(value);}",
-                        getElement()));
+        FieldValidationUtil.disableClientValidation(this);
     }
 
     /**

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -505,9 +505,9 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     }
 
     @Override
-    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
+    public void setRequiredIndicatorVisible(boolean required) {
         super.setRequiredIndicatorVisible(required);
-        this.required = requiredIndicatorVisible;
+        this.required = required;
     }
 
     /**

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -84,7 +84,6 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
      */
     public DatePicker(LocalDate initialDate) {
         super(initialDate, null, String.class, PARSER, FORMATTER);
-        getElement().synchronizeProperty("invalid", "invalid-changed");
         setLocale(UI.getCurrent().getLocale());
 
         // workaround for https://github.com/vaadin/flow/issues/3496
@@ -93,7 +92,9 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
         addValueChangeListener(e -> validate());
 
         addAttachListener(e ->
-                getElement().executeJs("$0.validate = function () {return this.checkValidity();}",
+                getElement().executeJs("$0.validate = function (value) {" +
+                                "value = value !== undefined ? value : this._inputValue;" +
+                                "return this.checkValidity(value);}",
                         getElement()));
     }
 

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/FieldValidationUtil.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/FieldValidationUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasValidation;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
+
+/**
+ * Utility class for date picker web component to disable client
+ * side validation.
+ *
+ * @author Vaadin Ltd
+ */
+final class FieldValidationUtil {
+
+    private FieldValidationUtil() {
+        // utility class should not be instantiated
+    }
+
+    static void disableClientValidation(Component component) {
+        // if the component was already attached override the validate()
+        overrideClientValidation(component);
+
+        component.addAttachListener(e -> overrideClientValidation(component));
+    }
+
+    private static void overrideClientValidation(Component component) {
+        PendingJavaScriptResult javaScriptResult =
+                component.getElement()
+                        .executeJs("$0.validate = function (value) {" +
+                            "value = value !== undefined ? value : this._inputValue;" +
+                            "return this.checkValidity(value);}",
+                                component.getElement());
+
+        javaScriptResult.then(result -> {
+            if (component instanceof HasValidation && ((HasValidation) component).isInvalid()) {
+                // By default, the invalid flag is always false when a component is created.
+                // However, if the component is populated and validated in the same HTTP request,
+                // the server side state may have changed before the JavaScript disabling client
+                // side validation was properly executed. This can sometimes lead to a situation
+                // side validation was properly executed. This can sometimes lead to a situation
+                // where the client side thinks the value is valid (before client side validation
+                // was disabled) and the server side thinks the value is invalid. This will lead to
+                // strange behavior until the two states are synchronized again. To avoid this, we will
+                // explicitly change the client side value if the server side is invalid.
+                component.getElement().executeJs("$0.invalid = true",
+                        component.getElement());
+            }
+        });
+    }
+}

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/FieldValidationUtil.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/FieldValidationUtil.java
@@ -41,10 +41,10 @@ final class FieldValidationUtil {
     private static void overrideClientValidation(Component component) {
         PendingJavaScriptResult javaScriptResult =
                 component.getElement()
-                        .executeJs("$0.validate = function (value) {" +
+                        .executeJs("this.validate = function (value) {" +
                             "value = value !== undefined ? value : this._inputValue;" +
-                            "return this.checkValidity(value);}",
-                                component.getElement());
+                            "return this.checkValidity(value);};" +
+                            "this._validateInput = function (date, min, max) {}");
 
         javaScriptResult.then(result -> {
             if (component instanceof HasValidation && ((HasValidation) component).isInvalid()) {
@@ -57,8 +57,7 @@ final class FieldValidationUtil {
                 // was disabled) and the server side thinks the value is invalid. This will lead to
                 // strange behavior until the two states are synchronized again. To avoid this, we will
                 // explicitly change the client side value if the server side is invalid.
-                component.getElement().executeJs("$0.invalid = true",
-                        component.getElement());
+                component.getElement().executeJs("this.invalid = true");
             }
         });
     }

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1201,8 +1201,8 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
                 modelToPresentation);
         if (initialValue != null) {
             setModelValue(initialValue, false);
-            setPresentationValue(initialValue);
         }
+       setPresentationValue(initialValue);
     }
 
     /**

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -947,14 +947,10 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * </p>
      * <p>
      * This property is set to true when the control value invalid.
-     * <p>
-     * This property is synchronized automatically from client side when a
-     * 'invalid-changed' event happens.
      * </p>
      *
      * @return the {@code invalid} property from the webcomponent
      */
-    @Synchronize(property = "invalid", value = "invalid-changed")
     protected boolean isInvalidBoolean() {
         return getElement().getProperty("invalid", false);
     }
@@ -1201,8 +1197,8 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
                 modelToPresentation);
         if (initialValue != null) {
             setModelValue(initialValue, false);
+            setPresentationValue(initialValue);
         }
-       setPresentationValue(initialValue);
     }
 
     /**

--- a/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -52,7 +52,7 @@ public class DatePickerTest {
         DatePicker picker = new DatePicker();
 
         assertEquals(null, picker.getValue());
-        assertEquals("", picker.getElement().getProperty("value"));
+        assertFalse(picker.getElement().hasProperty("value"));
 
         picker.setValue(LocalDate.of(2018, 4, 25));
         assertEquals("2018-04-25", picker.getElement().getProperty("value"));
@@ -67,12 +67,10 @@ public class DatePickerTest {
     }
 
     @Test
-    public void defaultCtor_sets_empty_value() {
+    public void defaultCtor_does_not_update_values() {
         DatePicker picker = new DatePicker();
         assertNull(picker.getValue());
-        // The constructor needs to set the value to empty to avoid triggering
-        // an update when the component is loaded
-        assertEquals("", picker.getElement().getProperty("value"));
+        assertEquals(null, picker.getElement().getProperty("value"));
     }
 
     @Test

--- a/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -52,7 +52,7 @@ public class DatePickerTest {
         DatePicker picker = new DatePicker();
 
         assertEquals(null, picker.getValue());
-        assertFalse(picker.getElement().hasProperty("value"));
+        assertEquals("", picker.getElement().getProperty("value"));
 
         picker.setValue(LocalDate.of(2018, 4, 25));
         assertEquals("2018-04-25", picker.getElement().getProperty("value"));
@@ -67,10 +67,12 @@ public class DatePickerTest {
     }
 
     @Test
-    public void defaultCtor_does_not_update_values() {
+    public void defaultCtor_sets_empty_value() {
         DatePicker picker = new DatePicker();
         assertNull(picker.getValue());
-        assertEquals(null, picker.getElement().getProperty("value"));
+        // The constructor needs to set the value to empty to avoid triggering
+        // an update when the component is loaded
+        assertEquals("", picker.getElement().getProperty("value"));
     }
 
     @Test
@@ -121,7 +123,8 @@ public class DatePickerTest {
         assertClearButtonPropertyValueEquals(picker, false);
     }
 
-    public void assertClearButtonPropertyValueEquals(DatePicker picker, Boolean value) {
+    public void assertClearButtonPropertyValueEquals(DatePicker picker,
+            Boolean value) {
         picker.setClearButtonVisible(value);
         assertEquals(value, picker.isClearButtonVisible());
         assertEquals(picker.isClearButtonVisible(),


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-date-picker-flow/issues/203
Based on the approach used in https://github.com/vaadin/vaadin-text-field-flow/pull/261
Reuses test from https://github.com/vaadin/vaadin-date-picker-flow/pull/205

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker-flow/206)
<!-- Reviewable:end -->
