### PR TITLE
Fix connector to work with years before 1000 (old version)

### DIFF
--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
@@ -252,6 +252,7 @@ package com.vaadin.flow.component.datepicker;
             // end-source-example
             locale1.setId("Locale-US");
             locale2.setId("Locale-UK");
+            locale3.setId("Locale-CHINA");
             datePicker.setId("locale-change-picker");
             addCard("Date picker with customize locales", datePicker, locale1,
                     locale2, locale3, message);

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -184,6 +184,12 @@ public class DatePickerIT extends ComponentDemoTest {
                 "25/03/2018", localePicker.getInputValue());
     }
 
+    private void setDateAndAssert(DatePickerElement datePicker, LocalDate date,
+            String expectedInputValue) {
+        datePicker.setDate(date);
+        Assert.assertEquals(expectedInputValue, datePicker.getInputValue());
+    }
+
     @Test
     public void selectDatesBeforeYear1000() {
         DatePickerElement localePicker = $(DatePickerElement.class)
@@ -191,37 +197,57 @@ public class DatePickerIT extends ComponentDemoTest {
         TestBenchElement message = $("div")
                 .id("Customize-locale-picker-message");
 
-        localePicker.setDate(LocalDate.of(900, Month.MARCH, 7));
-        Assert.assertEquals("3/7/0900", localePicker.getInputValue());
-        localePicker.setDate(LocalDate.of(87, Month.MARCH, 7));
-        Assert.assertEquals("3/7/0087", localePicker.getInputValue());
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 7),
+                "3/7/0900");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 7),
+                "3/7/0087");
 
         $("button").id("Locale-UK").click();
         Assert.assertEquals("07/03/0087", localePicker.getInputValue());
 
-        localePicker.setDate(LocalDate.of(900, Month.MARCH, 6));
-        Assert.assertEquals("06/03/0900", localePicker.getInputValue());
-        localePicker.setDate(LocalDate.of(87, Month.MARCH, 6));
-        Assert.assertEquals("06/03/0087", localePicker.getInputValue());
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 6),
+                "06/03/0900");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 6),
+                "06/03/0087");
 
         $("button").id("Locale-US").click();
         Assert.assertEquals("3/6/0087", localePicker.getInputValue());
 
-        localePicker.setDate(LocalDate.of(900, Month.MARCH, 5));
-        Assert.assertEquals("3/5/0900", localePicker.getInputValue());
-        localePicker.setDate(LocalDate.of(87, Month.MARCH, 5));
-        Assert.assertEquals("3/5/0087", localePicker.getInputValue());
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 5),
+                "3/5/0900");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 5),
+                "3/5/0087");
 
         $("button").id("Locale-CHINA").click();
         Assert.assertEquals("0087/3/5", localePicker.getInputValue());
 
-        localePicker.setDate(LocalDate.of(900, Month.MARCH, 4));
-        Assert.assertEquals("0900/3/4", localePicker.getInputValue());
-        localePicker.setDate(LocalDate.of(87, Month.MARCH, 4));
-        Assert.assertEquals("0087/3/4", localePicker.getInputValue());
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 4),
+                "0900/3/4");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 4),
+                "0087/3/4");
 
         $("button").id("Locale-UK").click();
         Assert.assertEquals("04/03/0087", localePicker.getInputValue());
+    }
+
+    /**
+     * Expects input value to change to expectedInputValue after setting it.
+     */
+    private void setInputValueAndAssert(DatePickerElement datePicker,
+            String inputValue, String expectedInputValue,
+            LocalDate expectedDate) {
+        datePicker.setInputValue(inputValue);
+        Assert.assertEquals(expectedInputValue, datePicker.getInputValue());
+        Assert.assertEquals(expectedDate, datePicker.getDate());
+    }
+
+    /**
+     * Expects input value to stay the same as it is set to.
+     */
+    private void setInputValueAndAssert(DatePickerElement datePicker,
+            String inputValue, LocalDate expectedDate) {
+        setInputValueAndAssert(datePicker, inputValue, inputValue,
+                expectedDate);
     }
 
     @Test
@@ -231,101 +257,53 @@ public class DatePickerIT extends ComponentDemoTest {
         TestBenchElement message = $("div")
                 .id("Customize-locale-picker-message");
 
-        localePicker.setInputValue("3/7/0900");
-        Assert.assertEquals("3/7/0900", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 7),
-                localePicker.getDate());
+        setInputValueAndAssert(localePicker, "3/7/0900",
+                LocalDate.of(900, Month.MARCH, 7));
 
-        localePicker.setInputValue("3/6/900");
-        Assert.assertEquals("3/6/0900", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 6),
-                localePicker.getDate());
-
-        localePicker.setInputValue("3/5/0087");
-        Assert.assertEquals("3/5/0087", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(87, Month.MARCH, 5),
-                localePicker.getDate());
-
-        localePicker.setInputValue("3/6/87");
-        Assert.assertEquals("3/6/1987", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(1987, Month.MARCH, 6),
-                localePicker.getDate());
-
-        localePicker.setInputValue("3/7/20");
-        Assert.assertEquals("3/7/2020", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(2020, Month.MARCH, 7),
-                localePicker.getDate());
-
-        localePicker.setInputValue("3/8/0020");
-        Assert.assertEquals("3/8/0020", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(20, Month.MARCH, 8),
-                localePicker.getDate());
+        setInputValueAndAssert(localePicker, "3/6/900", "3/6/0900",
+                LocalDate.of(900, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "3/5/0087",
+                LocalDate.of(87, Month.MARCH, 5));
+        setInputValueAndAssert(localePicker, "3/6/87", "3/6/1987",
+                LocalDate.of(1987, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "3/7/20", "3/7/2020",
+                LocalDate.of(2020, Month.MARCH, 7));
+        setInputValueAndAssert(localePicker, "3/8/0020",
+                LocalDate.of(20, Month.MARCH, 8));
 
         $("button").id("Locale-UK").click();
         Assert.assertEquals("08/03/0020", localePicker.getInputValue());
 
-        localePicker.setInputValue("7/3/0900");
-        Assert.assertEquals("07/03/0900", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 7),
-                localePicker.getDate());
+        setInputValueAndAssert(localePicker, "7/3/0900", "07/03/0900",
+                LocalDate.of(900, Month.MARCH, 7));
 
-        localePicker.setInputValue("6/3/900");
-        Assert.assertEquals("06/03/0900", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 6),
-                localePicker.getDate());
-
-        localePicker.setInputValue("5/3/0087");
-        Assert.assertEquals("05/03/0087", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(87, Month.MARCH, 5),
-                localePicker.getDate());
-
-        localePicker.setInputValue("6/3/87");
-        Assert.assertEquals("06/03/1987", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(1987, Month.MARCH, 6),
-                localePicker.getDate());
-
-        localePicker.setInputValue("7/3/20");
-        Assert.assertEquals("07/03/2020", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(2020, Month.MARCH, 7),
-                localePicker.getDate());
-
-        localePicker.setInputValue("8/3/0020");
-        Assert.assertEquals("08/03/0020", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(20, Month.MARCH, 8),
-                localePicker.getDate());
+        setInputValueAndAssert(localePicker, "6/3/900", "06/03/0900",
+                LocalDate.of(900, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "5/3/0087", "05/03/0087",
+                LocalDate.of(87, Month.MARCH, 5));
+        setInputValueAndAssert(localePicker, "6/3/87", "06/03/1987",
+                LocalDate.of(1987, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "7/3/20", "07/03/2020",
+                LocalDate.of(2020, Month.MARCH, 7));
+        setInputValueAndAssert(localePicker, "8/3/0020", "08/03/0020",
+                LocalDate.of(20, Month.MARCH, 8));
 
         $("button").id("Locale-CHINA").click();
         Assert.assertEquals("0020/3/8", localePicker.getInputValue());
 
-        localePicker.setInputValue("0900/3/7");
-        Assert.assertEquals("0900/3/7", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 7),
-                localePicker.getDate());
+        setInputValueAndAssert(localePicker, "0900/3/7",
+                LocalDate.of(900, Month.MARCH, 7));
 
-        localePicker.setInputValue("900/3/6");
-        Assert.assertEquals("0900/3/6", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(900, Month.MARCH, 6),
-                localePicker.getDate());
-
-        localePicker.setInputValue("0087/3/5");
-        Assert.assertEquals("0087/3/5", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(87, Month.MARCH, 5),
-                localePicker.getDate());
-
-        localePicker.setInputValue("87/3/6");
-        Assert.assertEquals("1987/3/6", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(1987, Month.MARCH, 6),
-                localePicker.getDate());
-
-        localePicker.setInputValue("20/3/7");
-        Assert.assertEquals("2020/3/7", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(2020, Month.MARCH, 7),
-                localePicker.getDate());
-
-        localePicker.setInputValue("0020/3/8");
-        Assert.assertEquals("0020/3/8", localePicker.getInputValue());
-        Assert.assertEquals(LocalDate.of(20, Month.MARCH, 8),
-                localePicker.getDate());
+        setInputValueAndAssert(localePicker, "900/3/6", "0900/3/6",
+                LocalDate.of(900, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "0087/3/5",
+                LocalDate.of(87, Month.MARCH, 5));
+        setInputValueAndAssert(localePicker, "87/3/6", "1987/3/6",
+                LocalDate.of(1987, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "20/3/7", "2020/3/7",
+                LocalDate.of(2020, Month.MARCH, 7));
+        setInputValueAndAssert(localePicker, "0020/3/8",
+                LocalDate.of(20, Month.MARCH, 8));
 
         $("button").id("Locale-US").click();
         Assert.assertEquals("3/8/0020", localePicker.getInputValue());

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.demo.ComponentDemoTest;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Integration tests for the {@link DatePickerView}.
+ * Integration tests for the {@link DatePickerViewDemoPage}.
  */
 public class DatePickerIT extends ComponentDemoTest {
 

--- a/vaadin-date-picker-flow-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -86,4 +86,25 @@ public class DatePickerElement extends TestBenchElement implements HasLabel {
     protected String getValue() {
         return getPropertyString("value");
     }
+
+    /**
+     * Opens the overlay, sets the value to the inner input element as a string
+     * and closes the overlay. This simulates the user typing into the input and
+     * triggering an update of the value property.
+     */
+    public void setInputValue(String value) {
+        executeScript("arguments[0].open();", this);
+        setProperty("_inputValue", value);
+        executeScript("arguments[0].close();", this);
+    }
+
+    /**
+     * Gets the visible presentation value from the inner input element as a
+     * string. This value depends on the used Locale.
+     *
+     * @return
+     */
+    public String getInputValue() {
+        return getPropertyString("_inputValue");
+    }
 }

--- a/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -3,15 +3,55 @@
         return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Date Picker', 'vaadin-date-picker-flow');
     };
 
-    /* helper class for parsing regex from formatted date string */
+    /**
+     * @typedef {object} DateHash
+     * @property {number} day - Day of month
+     * @property {number} month - Month (0 = January, 11 = December)
+     * @property {number} year - Year
+     */
 
+    /**
+     * @typedef {HTMLElement} DatePickerWithConnector
+     * @property {string} value
+     * @property {string} _inputValue
+     * @property {boolean} invalid
+     * @property {object} i18n
+     * @property {function|undefined} i18n.formatDate
+     * @property {function|undefined} i18n.parseDate
+     * @property {object} $connector
+     * @property {FlowDatePickerPart} $connector.dayPart
+     * @property {FlowDatePickerPart} $connector.monthPart
+     * @property {FlowDatePickerPart} $connector.yearPart
+     * @property {FlowDatePickerPart[]} $connector.parts
+     */
+
+    /**
+     * @typedef {Event} EventWithDatePickerTarget
+     * @property {DatePickerWithConnector} target
+     */
+
+    /**
+     * Helper class for parsing regex from formatted date string
+     * @typedef {object} FlowDatePickerPart
+     * @property {string} initial
+     * @property {number} index
+     * @property {number} value
+     */
     class FlowDatePickerPart {
+        /**
+         * @param {string} initial
+         */
         constructor(initial) {
             this.initial = initial;
             this.index = 0;
             this.value = 0;
         }
 
+        /**
+         * @param {FlowDatePickerPart} part1
+         * @param {FlowDatePickerPart} part2
+         * @returns {number}
+         */
         static compare(part1, part2) {
             if (part1.index < part2.index) {
                 return -1;
@@ -22,8 +62,9 @@
             return 0;
         }
     }
+
     window.Vaadin.Flow.datepickerConnector = {
-        initLazy: datepicker => tryCatchWrapper(function (datepicker) {
+        initLazy: datepicker => tryCatchWrapper(/** @param {DatePickerWithConnector} datepicker */ function (datepicker) {
             // Check whether the connector was already initialized for the datepicker
             if (datepicker.$connector) {
                 return;
@@ -43,21 +84,29 @@
             // value as we may need to parse user input so we can't use the _selectedDate value.
             let oldLocale = "en-us";
 
-            datepicker.addEventListener('blur', tryCatchWrapper(e => {
+            datepicker.addEventListener('blur', tryCatchWrapper(/** @param {EventWithDatePickerTarget} e */ e => {
                 if (!e.target.value && e.target.invalid) {
                     console.warn("Invalid value in the DatePicker.");
                 }
             }));
 
-            const cleanString = tryCatchWrapper(function (string) {
-                // Clear any non ascii characters from the date string,
-                // mainly the LEFT-TO-RIGHT MARK.
-                // This is a problem for many Microsoft browsers where `toLocaleDateString`
-                // adds the LEFT-TO-RIGHT MARK see https://en.wikipedia.org/wiki/Left-to-right_mark
+            /**
+             * Clear any non ascii characters from the date string,
+             * mainly the LEFT-TO-RIGHT MARK.
+             * This is a problem for many Microsoft browsers where `toLocaleDateString`
+             * adds the LEFT-TO-RIGHT MARK see https://en.wikipedia.org/wiki/Left-to-right_mark
+             * @param {string} string
+             * @returns {string}
+             */
+            let cleanString = function (string) {
                 return string.replace(/[^\x00-\x7F]/g, "");
-            });
+            };
+            cleanString = tryCatchWrapper(cleanString);
 
-            const getInputValue = tryCatchWrapper(function () {
+            /**
+             * @returns {string}
+             */
+            let getInputValue = function () {
                 let inputValue = '';
                 try {
                     inputValue = datepicker._inputValue;
@@ -66,10 +115,13 @@
                     inputValue = datepicker.value || '';
                 }
                 return inputValue;
-            });
+            };
+            getInputValue = tryCatchWrapper(getInputValue);
 
-            datepicker.$connector.setLocale = tryCatchWrapper(function (locale) {
-
+            /**
+             * @param {string} locale Locale string (e.g. 'en-US', 'fi-FI')
+             */
+            const setLocale = function (locale) {
                 try {
                     // Check whether the locale is supported or not
                     new Date().toLocaleDateString(locale);
@@ -78,9 +130,12 @@
                     console.warn("The locale is not supported, using default locale setting(en-US).");
                 }
 
-                let currentDate = false;
+                /** @type {DateHash} */
+                let currentDate;
+                /** @type {string} */
                 let inputValue = getInputValue();
-                if (datepicker.i18n.parseDate !== 'undefined' && inputValue) {
+
+                if (datepicker.i18n.parseDate && inputValue) {
                     /* get current date with old parsing */
                     currentDate = datepicker.i18n.parseDate(inputValue);
                 }
@@ -94,45 +149,100 @@
                 /* sort items to match correct places in regex groups */
                 datepicker.$connector.parts.sort(FlowDatePickerPart.compare);
                 /* create regex
-                * regex will be the date, so that:
-                * - day-part is '(\d{1,2})' (1 or 2 digits),
-                * - month-part is '(\d{1,2})' (1 or 2 digits),
-                * - year-part is '(\d{4})' (4 digits)
-                *
-                * and everything else is left as is.
-                * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{4})".
-                *
-                * The sorting part solves that which part is which (for example,
-                * here the first part is month, second day and third year)
-                *  */
-                datepicker.$connector.regex = testString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&').replace(datepicker.$connector.dayPart.initial, "(\\d{1,2})").replace(datepicker.$connector.monthPart.initial, "(\\d{1,2})").replace(datepicker.$connector.yearPart.initial, "(\\d{4})");
+                 * regex will be the date, so that:
+                 * - day-part is '(\d{1,2})' (1 or 2 digits),
+                 * - month-part is '(\d{1,2})' (1 or 2 digits),
+                 * - year-part is '(\d{1,4})' (1 to 4 digits)
+                 *
+                 * and everything else is left as is.
+                 * For example, us date "10/20/2010" => "(\d{1,2})/(\d{1,2})/(\d{1,4})".
+                 *
+                 * The sorting part solves that which part is which (for example,
+                 * here the first part is month, second day and third year)
+                 */
+                datepicker.$connector.regex = testString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+                    .replace(datepicker.$connector.dayPart.initial, "(\\d{1,2})")
+                    .replace(datepicker.$connector.monthPart.initial, "(\\d{1,2})")
+                    .replace(datepicker.$connector.yearPart.initial, "(\\d{1,4})");
 
-                datepicker.i18n.formatDate = tryCatchWrapper(function (date) {
+                /**
+                 * @param {DateHash} date
+                 * @returns {number}
+                 */
+                let indexOfYearForFormattedDate = function (date) {
+                    const {parts, dayPart, monthPart, yearPart} = datepicker.$connector;
+                    let adjust = 0;
+                    for (let i = 1; i < 4; i++) {
+                        const part = parts[i - 1];
+                        if (part === dayPart && date.day < 10) {
+                            adjust -= 1;
+                        } else if (part === monthPart && date.month < 9) {
+                            adjust -= 1;
+                        } else if (part === yearPart) {
+                            return yearPart.index + adjust;
+                        }
+                    }
+                };
+                indexOfYearForFormattedDate = tryCatchWrapper(indexOfYearForFormattedDate);
+
+                /**
+                 * @param {DateHash} date
+                 * @returns {string}
+                 */
+                const formatDate = function (date) {
                     let rawDate = new Date(Date.UTC(date.year, date.month, date.day));
-                    return cleanString(rawDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
-                });
+                    if (date.year >= 0 && date.year <= 99) {
+                        // JS Date constructor converts years 0-99 to 1900-1999 so
+                        // this is needed to fix that when we want an explicit year.
+                        rawDate.setUTCFullYear(date.year);
+                    }
+                    let formattedDate = cleanString(rawDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
+                    if (date.year < 1000) {
+                        const yearIndex = indexOfYearForFormattedDate(date);
+                        const yearStr = String(date.year).replace(/\d+/, y => '0000'.substring(y.length) + y);
+                        formattedDate = formattedDate.substring(0, yearIndex) + yearStr + formattedDate.substring(yearIndex + String(date.year).length);
+                    }
+                    return formattedDate;
+                };
+                datepicker.i18n.formatDate = tryCatchWrapper(formatDate);
 
-                datepicker.i18n.parseDate = tryCatchWrapper(function (dateString) {
+                /**
+                 *
+                 * @param {string} dateString
+                 * @returns {DateHash|boolean|undefined}
+                 */
+                const parseDate = function (dateString) {
                     dateString = cleanString(dateString);
 
-                    if (dateString.length == 0) {
+                    if (dateString.length === 0) {
                         return;
                     }
 
                     let match = dateString.match(datepicker.$connector.regex);
-                    if (match && match.length == 4) {
+                    if (match && match.length === 4) {
+                        const {parts, dayPart, monthPart, yearPart} = datepicker.$connector;
+                        let year;
                         for (let i = 1; i < 4; i++) {
-                            datepicker.$connector.parts[i-1].value = parseInt(match[i]);
+                            const part = parts[i-1];
+                            const matchValue = match[i];
+                            part.value = parseInt(matchValue);
+                            if (part === yearPart) {
+                                year = part.value;
+                                if (matchValue.length < 3 && year >= 0) {
+                                    year += year < 50 ? 2000 : 1900;
+                                }
+                            }
                         }
                         return {
-                            day: datepicker.$connector.dayPart.value,
-                            month: datepicker.$connector.monthPart.value - 1,
-                            year: datepicker.$connector.yearPart.value
+                            day: dayPart.value,
+                            month: monthPart.value - 1,
+                            year
                         };
-                    }  else {
+                    } else {
                         return false;
                     }
-                });
+                };
+                datepicker.i18n.parseDate = tryCatchWrapper(parseDate);
 
                 if (inputValue === "") {
                     oldLocale = locale;
@@ -140,7 +250,8 @@
                     /* set current date to invoke use of new locale */
                     datepicker._selectedDate = new Date(currentDate.year, currentDate.month, currentDate.day);
                 }
-            });
+            };
+            datepicker.$connector.setLocale = tryCatchWrapper(setLocale);
         })(datepicker)
     };
 })();

--- a/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -73,10 +73,10 @@
             datepicker.$connector = {};
 
             /* init helper parts for reverse-engineering date-regex */
-            datepicker.$connector.dayPart = new FlowDatePickerPart("22");
-            datepicker.$connector.monthPart = new FlowDatePickerPart("11");
-            datepicker.$connector.yearPart = new FlowDatePickerPart("1987");
-            datepicker.$connector.parts = [datepicker.$connector.dayPart, datepicker.$connector.monthPart, datepicker.$connector.yearPart];
+            const dayPart = datepicker.$connector.dayPart = new FlowDatePickerPart("22");
+            const monthPart = datepicker.$connector.monthPart = new FlowDatePickerPart("11");
+            const yearPart = datepicker.$connector.yearPart = new FlowDatePickerPart("1987");
+            const parts = datepicker.$connector.parts = [dayPart, monthPart, yearPart];
 
             // Old locale should always be the default vaadin-date-picker component
             // locale {English/US} as we init lazily and the date-picker formats
@@ -141,13 +141,13 @@
                 }
 
                 /* create test-string where to extract parsing regex */
-                let testDate = new Date(Date.UTC(datepicker.$connector.yearPart.initial, datepicker.$connector.monthPart.initial - 1, datepicker.$connector.dayPart.initial));
+                let testDate = new Date(Date.UTC(yearPart.initial, monthPart.initial - 1, dayPart.initial));
                 let testString = cleanString(testDate.toLocaleDateString(locale, { timeZone: 'UTC' }));
-                datepicker.$connector.parts.forEach(function (part) {
+                parts.forEach(function (part) {
                     part.index = testString.indexOf(part.initial);
                 });
                 /* sort items to match correct places in regex groups */
-                datepicker.$connector.parts.sort(FlowDatePickerPart.compare);
+                parts.sort(FlowDatePickerPart.compare);
                 /* create regex
                  * regex will be the date, so that:
                  * - day-part is '(\d{1,2})' (1 or 2 digits),
@@ -161,16 +161,15 @@
                  * here the first part is month, second day and third year)
                  */
                 datepicker.$connector.regex = testString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
-                    .replace(datepicker.$connector.dayPart.initial, "(\\d{1,2})")
-                    .replace(datepicker.$connector.monthPart.initial, "(\\d{1,2})")
-                    .replace(datepicker.$connector.yearPart.initial, "(\\d{1,4})");
+                    .replace(dayPart.initial, "(\\d{1,2})")
+                    .replace(monthPart.initial, "(\\d{1,2})")
+                    .replace(yearPart.initial, "(\\d{1,4})");
 
                 /**
                  * @param {DateHash} date
                  * @returns {number}
                  */
                 let indexOfYearForFormattedDate = function (date) {
-                    const {parts, dayPart, monthPart, yearPart} = datepicker.$connector;
                     let adjust = 0;
                     for (let i = 1; i < 4; i++) {
                         const part = parts[i - 1];
@@ -220,7 +219,6 @@
 
                     let match = dateString.match(datepicker.$connector.regex);
                     if (match && match.length === 4) {
-                        const {parts, dayPart, monthPart, yearPart} = datepicker.$connector;
                         let year;
                         for (let i = 1; i < 4; i++) {
                             const part = parts[i-1];

--- a/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow/src/main/resources/META-INF/resources/frontend/datepickerConnector.js
@@ -292,7 +292,13 @@
                     oldLocale = locale;
                 } else if (currentDate) {
                     /* set current date to invoke use of new locale */
-                    datepicker._selectedDate = new Date(currentDate.year, currentDate.month, currentDate.day);
+                    const rawDate = new Date(currentDate.year, currentDate.month, currentDate.day);
+                    if (currentDate.year >= 0 && currentDate.year <= 99) {
+                        // JS Date constructor converts years 0-99 to 1900-1999 so
+                        // this is needed to fix that when we want an explicit year.
+                        rawDate.setFullYear(currentDate.year);
+                    }
+                    datepicker._selectedDate = rawDate;
                 }
             };
             datepicker.$connector.setLocale = tryCatchWrapper(setLocale);


### PR DESCRIPTION
- Add JSDoc types to connector code to make it easier to spot mistakes and work with the code.
- Fix formatDate() to work with years before 1000
- formatDate() now always outputs the year with at least 4 digits adding zeros to the left when needed. This is now more consistent with how the default implementation of formatDate() works on the web component.
- Fix parseDate() to work with years when they are input with less than 4 digits
- parseDate() now accepts years with 1-4 digits and when it is input with 2 digits it is converted to range 1950-1999 or 2000-2049 (consistent with the web component version of parseDate).

Fixes #184