### PR TITLE
Fix connector to work with years before 1000

### DIFF
--- a/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
+++ b/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerViewDemoPage.java
@@ -252,6 +252,7 @@ package com.vaadin.flow.component.datepicker;
             // end-source-example
             locale1.setId("Locale-US");
             locale2.setId("Locale-UK");
+            locale3.setId("Locale-CHINA");
             datePicker.setId("locale-change-picker");
             addCard("Date picker with customize locales", datePicker, locale1,
                     locale2, locale3, message);

--- a/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
+++ b/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
+import java.time.Month;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,13 +24,14 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.datepicker.demo.DatePickerView;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
 import com.vaadin.flow.demo.ComponentDemoTest;
+import com.vaadin.testbench.TestBenchElement;
 
 import static org.junit.Assert.assertTrue;
 
 /**
- * Integration tests for the {@link DatePickerView}.
+ * Integration tests for the {@link DatePickerViewDemoPage}.
  */
 public class DatePickerIT extends ComponentDemoTest {
 
@@ -68,7 +70,8 @@ public class DatePickerIT extends ComponentDemoTest {
         Assert.assertEquals("The selected date should be considered valid",
                 false, executeScript("return arguments[0].invalid", picker));
 
-        waitUntil(driver -> message.getText().contains(("Day: " + now.getDayOfMonth() + "\nMonth: "
+        waitUntil(driver -> message.getText()
+                .contains(("Day: " + now.getDayOfMonth() + "\nMonth: "
                         + now.getMonthValue() + "\nYear: " + now.getYear())));
 
         executeScript("arguments[0].value = ''", picker);
@@ -184,8 +187,132 @@ public class DatePickerIT extends ComponentDemoTest {
 
         layout.findElement(By.id("Locale-UK")).click();
         assertTrue((Boolean) executeScript(
-                "return arguments[0].value === '25/03/2018'",
-                displayText));
+                "return arguments[0].value === '25/03/2018'", displayText));
+    }
+
+    private void setDateAndAssert(DatePickerElement datePicker, LocalDate date,
+            String expectedInputValue) {
+        datePicker.setDate(date);
+        Assert.assertEquals(expectedInputValue, datePicker.getInputValue());
+    }
+
+    @Test
+    public void selectDatesBeforeYear1000() {
+        DatePickerElement localePicker = $(DatePickerElement.class)
+                .id("locale-change-picker");
+        TestBenchElement message = $("div")
+                .id("Customize-locale-picker-message");
+
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 7),
+                "3/7/900");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 7),
+                "3/7/87");
+
+        $("button").id("Locale-UK").click();
+        Assert.assertEquals("07/03/87", localePicker.getInputValue());
+
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 6),
+                "06/03/900");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 6),
+                "06/03/87");
+
+        $("button").id("Locale-US").click();
+        Assert.assertEquals("3/6/87", localePicker.getInputValue());
+
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 5),
+                "3/5/900");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 5),
+                "3/5/87");
+
+        $("button").id("Locale-CHINA").click();
+        Assert.assertEquals("87/3/5", localePicker.getInputValue());
+
+        setDateAndAssert(localePicker, LocalDate.of(900, Month.MARCH, 4),
+                "900/3/4");
+        setDateAndAssert(localePicker, LocalDate.of(87, Month.MARCH, 4),
+                "87/3/4");
+
+        $("button").id("Locale-UK").click();
+        Assert.assertEquals("04/03/87", localePicker.getInputValue());
+    }
+
+    /**
+     * Expects input value to change to expectedInputValue after setting it.
+     */
+    private void setInputValueAndAssert(DatePickerElement datePicker,
+            String inputValue, String expectedInputValue,
+            LocalDate expectedDate) {
+        datePicker.setInputValue(inputValue);
+        Assert.assertEquals(expectedInputValue, datePicker.getInputValue());
+        Assert.assertEquals(expectedDate, datePicker.getDate());
+    }
+
+    /**
+     * Expects input value to stay the same as it is set to.
+     */
+    private void setInputValueAndAssert(DatePickerElement datePicker,
+            String inputValue, LocalDate expectedDate) {
+        setInputValueAndAssert(datePicker, inputValue, inputValue,
+                expectedDate);
+    }
+
+    @Test
+    public void selectDatesBeforeYear1000SimulateUserInput() {
+        DatePickerElement localePicker = $(DatePickerElement.class)
+                .id("locale-change-picker");
+        TestBenchElement message = $("div")
+                .id("Customize-locale-picker-message");
+
+        setInputValueAndAssert(localePicker, "3/7/0900", "3/7/900",
+                LocalDate.of(900, Month.MARCH, 7));
+
+        setInputValueAndAssert(localePicker, "3/6/900",
+                LocalDate.of(900, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "3/5/0087", "3/5/87",
+                LocalDate.of(87, Month.MARCH, 5));
+        setInputValueAndAssert(localePicker, "3/6/87",
+                LocalDate.of(87, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "3/7/20",
+                LocalDate.of(20, Month.MARCH, 7));
+        setInputValueAndAssert(localePicker, "3/8/0020", "3/8/20",
+                LocalDate.of(20, Month.MARCH, 8));
+
+        $("button").id("Locale-UK").click();
+        Assert.assertEquals("08/03/20", localePicker.getInputValue());
+
+        setInputValueAndAssert(localePicker, "7/3/0900", "07/03/900",
+                LocalDate.of(900, Month.MARCH, 7));
+
+        setInputValueAndAssert(localePicker, "6/3/900", "06/03/900",
+                LocalDate.of(900, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "5/3/0087", "05/03/87",
+                LocalDate.of(87, Month.MARCH, 5));
+        setInputValueAndAssert(localePicker, "6/3/87", "06/03/87",
+                LocalDate.of(87, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "7/3/20", "07/03/20",
+                LocalDate.of(20, Month.MARCH, 7));
+        setInputValueAndAssert(localePicker, "8/3/0020", "08/03/20",
+                LocalDate.of(20, Month.MARCH, 8));
+
+        $("button").id("Locale-CHINA").click();
+        Assert.assertEquals("20/3/8", localePicker.getInputValue());
+
+        setInputValueAndAssert(localePicker, "0900/3/7", "900/3/7",
+                LocalDate.of(900, Month.MARCH, 7));
+
+        setInputValueAndAssert(localePicker, "900/3/6",
+                LocalDate.of(900, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "0087/3/5", "87/3/5",
+                LocalDate.of(87, Month.MARCH, 5));
+        setInputValueAndAssert(localePicker, "87/3/6",
+                LocalDate.of(87, Month.MARCH, 6));
+        setInputValueAndAssert(localePicker, "20/3/7",
+                LocalDate.of(20, Month.MARCH, 7));
+        setInputValueAndAssert(localePicker, "0020/3/8", "20/3/8",
+                LocalDate.of(20, Month.MARCH, 8));
+
+        $("button").id("Locale-US").click();
+        Assert.assertEquals("3/8/20", localePicker.getInputValue());
     }
 
     @Override

--- a/vaadin-date-picker-flow-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -86,4 +86,25 @@ public class DatePickerElement extends TestBenchElement implements HasLabel {
     protected String getValue() {
         return getPropertyString("value");
     }
+
+    /**
+     * Opens the overlay, sets the value to the inner input element as a string
+     * and closes the overlay. This simulates the user typing into the input and
+     * triggering an update of the value property.
+     */
+    public void setInputValue(String value) {
+        executeScript("arguments[0].open();", this);
+        setProperty("_inputValue", value);
+        executeScript("arguments[0].close();", this);
+    }
+
+    /**
+     * Gets the visible presentation value from the inner input element as a
+     * string. This value depends on the used Locale.
+     *
+     * @return
+     */
+    public String getInputValue() {
+        return getPropertyString("_inputValue");
+    }
 }


### PR DESCRIPTION
- Fix formatDate() to work with years before 1000
- Fix parseDate() to work with years when they are input with less than 4 digits. parseDate() now accepts years with 1-4 digits.

Fixes #184

(This is a new version of the PR #230. This only has minimal changes to fix the issue without extra improvements.)