### PR TITLE
Set locale in onAttach instead of constructor

### DIFF
--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -303,9 +303,7 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
-        if (languageTag != null) {
-            setLocaleWithJS();
-        }
+        getUI().ifPresent(ui ->  setLocale(ui.getLocale()));
         if (i18n != null) {
             setI18nWithJS();
         }

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -82,7 +82,6 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
      */
     public DatePicker(LocalDate initialDate) {
         super(initialDate, null, String.class, PARSER, FORMATTER);
-        setLocale(UI.getCurrent().getLocale());
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);

--- a/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -302,7 +302,11 @@ public class DatePicker extends GeneratedVaadinDatePicker<DatePicker, LocalDate>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         initConnector();
-        getUI().ifPresent(ui ->  setLocale(ui.getLocale()));
+        if (locale == null) {
+            getUI().ifPresent(ui -> setLocale(ui.getLocale()));        	
+        } else if (languageTag != null) {
+            setLocaleWithJS();
+        }
         if (i18n != null) {
             setI18nWithJS();
         }


### PR DESCRIPTION
After attach, getUI() returns right ui instance

setLocale calls setLocaleWithJS, so explicit call can be removed

Fixes: https://github.com/vaadin/vaadin-date-picker-flow/issues/262